### PR TITLE
fix: add unittests to test member functions of a class

### DIFF
--- a/smoothie/king.py
+++ b/smoothie/king.py
@@ -1,4 +1,6 @@
 from functools import wraps
+import traceback
+
 
 from smoothie.exc import CallableCallbackException
 
@@ -18,7 +20,8 @@ class Dispenser(object):
                     if not callable(callback):
                         raise CallableCallbackException
                     else:
-                        kwargs['ex'] = ex.__dict__
+                        kwargs['exc_info'] = traceback.format_exc()
+                        kwargs['ex'] = ex
                         # HACK(TheSriram): Remove the self arg
                         return callback(args[1:], **kwargs)
             self.map[func.__name__] = func

--- a/smoothie/tests/test_smoothie.py
+++ b/smoothie/tests/test_smoothie.py
@@ -103,8 +103,6 @@ class SmoothieKingTest(unittest.TestCase):
         self.assertTrue('exc_info' in returns)
         self.assertEqual(raised_exception.__class__,
                          IndexError)
-        self.assertEqual(raised_exception.message,
-                         'list index out of range')
 
         with self.assertRaises(IndexError):
             orig_drink_error_args = juice.original('drink_error_args')

--- a/smoothie/tests/test_smoothie.py
+++ b/smoothie/tests/test_smoothie.py
@@ -71,3 +71,45 @@ class SmoothieKingTest(unittest.TestCase):
 
         with self.assertRaises(IndexError):
             func_not_captured_exception()
+
+
+    def test_smoothie_class_function(self):
+
+        self.was_called = False
+
+        def err_callback(*args, **kwargs):
+            self.was_called = True
+            return kwargs
+
+        juice = Dispenser()
+
+        class Drinks(object):
+            def __init__(self):
+                self.drinks = []
+                pass
+
+            @juice.attach(exception=IndexError,
+                          callback=err_callback)
+            def drink_error_args(self, new_drink):
+                self.was_called = False
+                self.new_drink = new_drink
+                self.drinks.append(self.new_drink)
+                return self.drinks[4]
+
+        drinks_obj = Drinks()
+        returns = drinks_obj.drink_error_args('Water')
+        raised_exception = returns['ex']
+
+        self.assertTrue('exc_info' in returns)
+        self.assertEqual(raised_exception.__class__,
+                         IndexError)
+        self.assertEqual(raised_exception.message,
+                         'list index out of range')
+
+        with self.assertRaises(IndexError):
+            orig_drink_error_args = juice.original('drink_error_args')
+            # NOTE(TheSriram): The first argument needs to be self,
+            # since the original function was a member function of a
+            # class. It can also be any object that closely matches
+            # the spec of `self`
+            orig_drink_error_args(drinks_obj, 'Coffee')


### PR DESCRIPTION
- save entire traceback under exc_info, and exception object as ex
  instead of just trying to save magic `__dict__`
